### PR TITLE
Fix 5 min cron job syntax and working on Editor

### DIFF
--- a/src/webviews/src/Step.tsx
+++ b/src/webviews/src/Step.tsx
@@ -68,7 +68,7 @@ export const Step: FunctionComponent<StepProps> = props => {
         <StepConfig stepIndex={props.index} step={props.step} />
 
         <FilePicker
-          title="Postprocessing file"
+          title="Postprocessing file (optional)"
           label="The file containing the postprocessing script. This needs to be within the same repository."
           value={props.step.with.postprocess}
           accept=".js,.ts"

--- a/src/webviews/src/StepConfig.tsx
+++ b/src/webviews/src/StepConfig.tsx
@@ -37,7 +37,7 @@ export function StepConfig(props: StepConfigProps) {
         <Input
           value={props.step.with.downloaded_filename || ''}
           placeholder="data"
-          title="Result filename"
+          title="Downloaded filename"
           label="The filename where you want the results to be saved. This file doesn't need to exist yet."
           handleChange={e =>
             handleHttpValueChange(
@@ -62,8 +62,8 @@ export function StepConfig(props: StepConfigProps) {
         <Input
           value={props.step.with.downloaded_filename || ''}
           placeholder="data"
-          title="Ingested filename"
-          label="The filename (with extension) where you want the results to be saved. This file doesn't need to exist yet."
+          title="Downloaded filename"
+          label="The filename (with a csv or json extension) where you want the results to be saved. This file doesn't need to exist yet."
           handleChange={e =>
             handleSqlValueChange('downloaded_filename', e.target.value)
           }

--- a/src/webviews/src/settings/CronChooser.tsx
+++ b/src/webviews/src/settings/CronChooser.tsx
@@ -8,13 +8,13 @@ type CronChooserProps = {
 }
 
 const defaultSchedules = {
-  fiveMinutes: '* * * * *',
+  fiveMinutes: '*/5 * * * *',
   hour: '0 * * * *',
   day: '0 0 * * *',
 }
 
 const CronChooser: FunctionComponent<CronChooserProps> = props => {
-  const [customCron, setCustomCron] = React.useState('* * * * *')
+  const [customCron, setCustomCron] = React.useState('*/5 * * * *')
   const [showCustom, setShowCustom] = React.useState(false)
   const [cronFeedback, setCronFeedback] = React.useState<string | Error>('')
 


### PR DESCRIPTION
Fixes:

- Cron job 5 min syntax from '* * * * *' to '*/5 * * * *'


Changes:

- Adds "optional" tag to postprocessing section
- Changes "inject file" to "Downloaded filename" in both http and sql
- Mentions that sql filename has to be csv or json