### PR TITLE
version: bump Flat Action version to flat@v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flat",
   "displayName": "Flat Editor",
   "description": "An editor for flat-data configurations",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "publisher": "githubocto",
   "repository": {
     "type": "git",

--- a/src/webviews/src/Jobs.tsx
+++ b/src/webviews/src/Jobs.tsx
@@ -10,14 +10,14 @@ interface JobsProps {}
 const STEP_STUBS = {
   http: {
     name: 'Fetch data',
-    uses: 'githubocto/flat@v2',
+    uses: 'githubocto/flat@v3',
     with: {
       http_url: '',
     },
   },
   sql: {
     name: 'Fetch data',
-    uses: 'githubocto/flat@v2',
+    uses: 'githubocto/flat@v3',
     with: {
       sql_connstring: '',
       sql_queryfile: '',


### PR DESCRIPTION
This is because the Flat Action itself was upgraded to v3 because of a backwards incompatible change of [restricting Deno scopes](https://github.com/githubocto/flat/pull/18).