### PR TITLE
fix: disallow node modules from FilePicker

### DIFF
--- a/src/flatConfigEditor.ts
+++ b/src/flatConfigEditor.ts
@@ -385,6 +385,7 @@ export class FlatConfigEditor implements vscode.CustomTextEditorProvider {
         workspaceRootUri.path + '/**/*',
         `!${workspaceRootUri.path}/.git`,
         `!${workspaceRootUri.path}/.vscode`,
+        `!${workspaceRootUri.path}/node_modules`,
       ],
       { dot: true }
     )

--- a/src/webviews/src/Step.tsx
+++ b/src/webviews/src/Step.tsx
@@ -12,19 +12,13 @@ type StepProps = {
 }
 
 export const Step: FunctionComponent<StepProps> = props => {
-  const { state, update, errors } = useFlatConfigStore()
+  const update = useFlatConfigStore(state => state.update)
 
-  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newName = e.target.value
-    update(store => {
-      store.state.jobs.scheduled.steps[props.index].name = newName
-    })
-  }
   const handlePostprocessChange = (newPath?: string) => {
     update(store => {
-      ;(store.state.jobs.scheduled.steps[
-        props.index
-      ] as FlatStep).with.postprocess = newPath
+      ;(
+        store.state.jobs.scheduled.steps[props.index] as FlatStep
+      ).with.postprocess = newPath
     })
   }
 

--- a/src/webviews/src/settings/FilePicker.tsx
+++ b/src/webviews/src/settings/FilePicker.tsx
@@ -32,7 +32,7 @@ interface FilePickerProps {
 export function FilePicker(props: FilePickerProps) {
   const { label, value, onChange, accept = '', title } = props
   const [localValue, setLocalValue] = React.useState(value)
-  const { files = [] } = useFlatConfigStore()
+  const files = useFlatConfigStore(state => state.files || [])
 
   useEffect(() => {
     if (localValue === '' && Boolean(value)) {


### PR DESCRIPTION
I ran into a nasty UX issue when editing a `flat.yml` inside of a Next.js project. The extension looked like it was stuck in a "save loop," meaning I couldn't type in any of the text fields and the UI was totally unresponsive. After digging around, I isolated the problem to the `FilePicker` component. The issue was that our extension backend was passing down all of the files in `node_modules` as `files` which put the UI into a bad state.

<img width="307" alt="Screen Shot 2022-04-05 at 1 30 47 PM" src="https://user-images.githubusercontent.com/5148596/161816952-08133617-000c-42ba-9459-70e015fb4b84.png">

By disallowing `node_modules` the UI is back to its snappy self. While I was poking around, I did some light refactoring by making our Zustand state picks more atomic.

