### PR TITLE
fix: exclude all node_modules files

### DIFF
--- a/src/flatConfigEditor.ts
+++ b/src/flatConfigEditor.ts
@@ -385,7 +385,7 @@ export class FlatConfigEditor implements vscode.CustomTextEditorProvider {
         workspaceRootUri.path + '/**/*',
         `!${workspaceRootUri.path}/.git`,
         `!${workspaceRootUri.path}/.vscode`,
-        `!${workspaceRootUri.path}/node_modules`,
+        `!${workspaceRootUri.path}/**/node_modules`,
       ],
       { dot: true }
     )


### PR DESCRIPTION
Currently, our file picker component chokes when too many eligible files are passed to it.

Typically, from what we've seen, flat data repos tend not to have too many files in them. But, say, if you co-locate a Next.js app in your repository (either at the root, or nested in a directory), we want to make sure we exclude all of the files in `node_modules` to prevent the aforementioned choking.